### PR TITLE
make the UID column a string

### DIFF
--- a/pkg/sinks/clickhouse.go
+++ b/pkg/sinks/clickhouse.go
@@ -45,7 +45,7 @@ const (
 	Kind LowCardinality(String),
 	Namespace LowCardinality(String),
 	Name LowCardinality(String),
-	UID UUID,
+	UID String,
 	ResourceVersion String,
 	FieldPath Nullable(String),
 	Labels Map(String, String),


### PR DESCRIPTION
the `uid` type in kubernetes is just an alias to the string type and makes no restrictions about the structure of the uid. While all k8s controllers set proper uuids, there are other components like some EKS controllers that don't